### PR TITLE
De juiste Nederlandse vertaling van momentum gebruiken

### DIFF
--- a/data/battle_tower/trainer_text.asm
+++ b/data/battle_tower/trainer_text.asm
@@ -609,7 +609,7 @@ _BTWinF14Text:
 
 _BTGreetingF15Text:
 	text "OK, daar gaan we!" ; "OK, here goes!"
-	line "Ik heb momentum!" ; "I have momentum!"
+	line "Ik heb impuls!" ; "I have momentum!"
 	done
 
 _BTLossF15Text:

--- a/data/pokemon/dex_entries/aipom.asm
+++ b/data/pokemon/dex_entries/aipom.asm
@@ -7,5 +7,5 @@
 	next "takken te hangen." ; "branches. It uses"
 
 	page "Slingert met" ; "its momentum to"
-	next "momentum van" ; "swing from one"
+	next "impuls van" ; "swing from one"
 	next "tak naar tak.@" ; "branch to another.@"


### PR DESCRIPTION
Bedankt voor het maken van deze Nederlandse vertaling, het ziet er heel erg goed uit.
`Lanterfanten` is een mooie vertaling voor `goofing off`!

Ik heb één verbetering voor de volgende versie: in de natuurkunde wordt in het Engels het woord `momentum` gebruikt voor het Nederlandse `impuls`.
Zie onder andere Wikipedia:

- https://en.wikipedia.org/wiki/Momentum
- https://nl.wikipedia.org/wiki/Impuls_(natuurkunde)